### PR TITLE
Check for OneAPI TBB and include/exclude necessary headers

### DIFF
--- a/src/algevo/tools/cvt.hpp
+++ b/src/algevo/tools/cvt.hpp
@@ -40,6 +40,12 @@
 
 #ifdef USE_TBB
 #include <tbb/tbb.h>
+
+#ifdef USE_ONEAPI_TBB
+#include <oneapi/tbb/mutex.h>
+using namespace oneapi;
+#endif
+
 #endif
 
 #include <Eigen/Core>

--- a/src/algevo/tools/parallel.hpp
+++ b/src/algevo/tools/parallel.hpp
@@ -37,7 +37,14 @@
 #ifdef USE_TBB
 #include <tbb/parallel_for.h>
 #include <tbb/parallel_for_each.h>
+
+#ifndef USE_ONEAPI_TBB
 #include <tbb/task_scheduler_init.h>
+#else
+#include <oneapi/tbb/global_control.h>
+using namespace oneapi;
+#endif
+
 #endif
 
 namespace algevo {
@@ -45,7 +52,12 @@ namespace algevo {
 #ifdef USE_TBB
         inline void parallel_init(int threads = -1)
         {
+#ifndef USE_ONEAPI_TBB
             static tbb::task_scheduler_init init(threads);
+#else
+            static tbb::global_control global_limit(tbb::global_control::max_allowed_parallelism, threads);
+
+#endif
         }
 #else
         inline void parallel_init()
@@ -80,6 +92,6 @@ namespace algevo {
         }
 
     } // namespace tools
-} // namespace ge
+} // namespace algevo
 
 #endif

--- a/waf_tools/tbb.py
+++ b/waf_tools/tbb.py
@@ -80,6 +80,18 @@ def check_tbb(self, *k, **kw):
         self.end_msg('Not found in %s' % str(includes_tbb), 'YELLOW')
         return
 
+    # check for oneapi vs older tbb
+    self.start_msg('Checking for Intel OneAPI TBB')
+    using_oneapi = False
+    try:
+        incl = get_directory('oneapi/tbb.h', includes_tbb)
+        self.end_msg(incl)
+        using_oneapi = True
+    except:
+        self.end_msg('Not found in %s, reverting to older TBB' % str(includes_tbb), 'YELLOW')
+        return
+
+
     self.start_msg('Checking Intel TBB libs')
     try:
         lib = check_lib(self, 'libtbb', libpath_tbb)
@@ -94,3 +106,5 @@ def check_tbb(self, *k, **kw):
     self.env.LIB_TBB = ['tbb']
     self.env.INCLUDES_TBB = [incl]
     self.env.DEFINES_TBB = ['USE_TBB']
+    if using_oneapi:
+        self.env.DEFINES_TBB += ['USE_ONEAPI_TBB']


### PR DESCRIPTION
1. Tweaked the tbb waf tool to create an additional define flag if OneAPI exists in the system
2. Added preprocessor checks to include or exclude header files for the newer OneAPI TBB. Same goes for the namespace oneapi.