### PR TITLE
Support random shuffling in cpp versions > 14

### DIFF
--- a/src/algevo/tools/cvt.hpp
+++ b/src/algevo/tools/cvt.hpp
@@ -34,7 +34,8 @@
 #ifndef ALGEVO_TOOLS_CVT_HPP
 #define ALGEVO_TOOLS_CVT_HPP
 
-#include <algorithm> //for random_shuffle
+#include <algorithm>
+#include <random>
 #include <numeric> //for iota
 #include <vector>
 
@@ -61,7 +62,13 @@ namespace algevo {
 
                 std::vector<unsigned int> indices(data.cols());
                 std::iota(indices.begin(), indices.end(), 0);
+#if __cplusplus > 201402L
+                std::random_device rd;
+                std::mt19937 g(rd());
+                std::shuffle(indices.begin(), indices.end(), g);
+#else
                 std::random_shuffle(indices.begin(), indices.end());
+#endif
 
                 // Create the centroids
                 unsigned int dim = data.rows();


### PR DESCRIPTION
std::random_shuffle is deprecated in C++17 and on. I added a small check to use std::shuffle in newer compilers. 